### PR TITLE
Fixed FreeBSD and some Linux compilations

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -29,35 +29,40 @@ if test $PHP_PHPLPSOLVE55 != "no"; then
   dnl Find the shared library:
   LDFLAGS="-Wl,--no-as-needed"
   for i in /usr/local/lib /usr/lib /lib; do
-    if test -r "$i/liblpsolve55.so"; then
-      PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
-          PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, $i, PHPLPSOLVE55_SHARED_LIBADD)
+    for j in lpsolve55_pic lpsolve55; do
+      if test -r "$i/lib$j.so"; then
+        PHP_CHECK_LIBRARY($j, make_lp,[
+            PHP_ADD_LIBRARY_WITH_PATH($j, $i, PHPLPSOLVE55_SHARED_LIBADD)
+            PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
+            LIBLPSOLVE_LIBDIR="$i"
+            break 2
+          ],[
+            continue
+          ],[
+            -L$i $EXTRA_LIBS
+          ]
+        )
+      fi
+    done
+  done
+
+  for i in lpsolve55_pic lpsolve55; do
+    if test -z "$LIBLPSOLVE_LIBDIR"; then
+    PHP_CHECK_LIBRARY($i, make_lp,[
+          PHP_ADD_LIBRARY($i, 1, PHPLPSOLVE55_SHARED_LIBADD)
           PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
           LIBLPSOLVE_LIBDIR="$i"
-          break
         ],[
-          continue
+          AC_MSG_ERROR([Could not find liblpsolve55.so or symbol make_lp.  Check version and config.log for more information.])
         ],[
-          -L$i $EXTRA_LIBS
+          $EXTRA_LIBS
         ]
       )
     fi
   done
-
-  if test -z "$LIBLPSOLVE_LIBDIR"; then
-  PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
-        PHP_ADD_LIBRARY(lpsolve55, 1, PHPLPSOLVE55_SHARED_LIBADD)
-        PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
-        LIBLPSOLVE_LIBDIR="$i"
-      ],[
-        AC_MSG_ERROR([Could not find liblpsolve55.so or symbol make_lp.  Check version and config.log for more information.])
-      ],[
-        $EXTRA_LIBS
-      ]
-    )
-  fi
   LDFLAGS=""
   AC_DEFINE(DEMO,1,[DEMO code in lpsolve])
   AC_DEFINE(PHP,1,[liblpsolve55 found and included])
+  PHP_SUBST(PHPLPSOLVE55_SHARED_LIBADD)
   PHP_NEW_EXTENSION(phplpsolve55, PHPmod.c hash.c lpsolve.c, $ext_shared)
 fi

--- a/config.m4
+++ b/config.m4
@@ -1,20 +1,79 @@
-PHP_ARG_WITH(phplpsolve55,[lpsolve 5.5]
-[  with-phplpsolve55=[Insert path to lp_solve here]            Include lpsolve Support])
+PHP_ARG_WITH(phplpsolve55, for liblpsolve55,
+[ --with-phplpsolve55=DIR Installation prefix of liblpsolve55.
+                          If DIR is not specified, use the system library.])
 
 if test $PHP_PHPLPSOLVE55 != "no"; then
-  if test -f "$PHP_PHPLPSOLVE55/lp_lib.h"; then
-    PHP_CHECK_LIBRARY(lpsolve55, make_lp,,[AC_MSG_ERROR([Invalid phplpsolve55 library, make_lp() not found])],-L/usr/lib)
-  else
-    dnl This will cancel configuration if the required headers aren't found
-    AC_MSG_ERROR([lp_lib.h not found])
+#  if test -f "$PHP_PHPLPSOLVE55/lp_lib.h"; then
+#    PHP_CHECK_LIBRARY(lpsolve55, make_lp,,[AC_MSG_ERROR([Invalid phplpsolve55 library, make_lp() not found])])
+#  else
+#    dnl This will cancel configuration if the required headers aren't found
+#    AC_MSG_ERROR([lp_lib.h not found])
+#  fi
+
+#  PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, /usr/local/lib, PHPLPSOLVE55_SHARED_LIBADD)
+  #PHP_ADD_LIBRARY(lpsolve55,, PHPLPSOLVE55_SHARED_LIBADD)
+  #PHP_ADD_LIBRARY(lpsolve55)
+  EXTRA_LIBS="-lm"
+  #AC_MSG_ERROR($LDFLAGS)
+  AC_CHECK_LIB(dl, dlopen, [
+    EXTRA_LIBS="$EXTRA_LIBS -ldl"
+    PHP_ADD_LIBRARY(dl, 1, PHPLPSOLVE55_SHARED_LIBADD)
+  ])
+  AC_CHECK_LIB(colamd, colamd, [
+    EXTRA_LIBS="$EXTRA_LIBS -lcolamd"
+  ])
+  dnl Find the header file:
+  AC_MSG_CHECKING([for lp_lib.h])
+  for i in $PHP_PHPLPSOLVE55 /usr/include/lpsolve /usr/local/include/lpsolve; do
+    if test -r "$i/lp_lib.h"; then
+      LIBLPSOLVE_INCDIR="$i"
+      AC_MSG_RESULT($i)
+      break
+    fi
+  done
+
+  if test -z "$LIBLPSOLVE_INCDIR"; then
+    AC_MSG_RESULT([not found])
+    AC_MSG_ERROR([Could not find lp_lib.h])
   fi
 
-  PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, /usr/local/lib, PHPLPSOLVE55_SHARED_LIBADD)
-  PHP_ADD_INCLUDE($PHP_PHPLPSOLVE55)
-  AC_MSG_RESULT([lpsolve in $PHP_PHPLPSOLVE55])
-  AC_DEFINE(PHP,1,[liblpsolve55 found and included])
+  dnl Find the shared library:
+  LDFLAGS="-Wl,--no-as-needed"
+  for i in /usr/local/lib /usr/lib /lib; do
+    if test -r "$i/liblpsolve55.so"; then
+      PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
+          #AC_DEFINE([HAVE_LIBLPSOLVE55], 1, [liblpsolve55 found and included])
+          PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, $i, PHPLPSOLVE55_SHARED_LIBADD)
+          PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
+          LIBLPSOLVE_LIBDIR="$i"
+          break
+        ],[
+          continue
+        ],[
+          -L$i $EXTRA_LIBS
+        ]
+      )
+    fi
+  done
+
+  if test -z "$LIBLPSOLVE_LIBDIR"; then
+  PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
+        #AC_DEFINE([HAVE_LIBLPSOLVE55], 1, [liblpsolve55 found and included])
+        PHP_ADD_LIBRARY(lpsolve55, 1, PHPLPSOLVE55_SHARED_LIBADD)
+        PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
+        LIBLPSOLVE_LIBDIR="$i"
+      ],[
+        AC_MSG_ERROR([Could not find liblpsolve55.so or symbol make_lp.  Check version and config.log for more information.])
+      ],[
+        $EXTRA_LIBS
+      ]
+    )
+  fi
+  LDFLAGS=""
   AC_DEFINE(DEMO,1,[DEMO code in lpsolve])
+  AC_DEFINE(PHP,1,[liblpsolve55 found and included])
   PHP_NEW_EXTENSION(phplpsolve55, PHPmod.c hash.c lpsolve.c, $ext_shared)
+  #AC_MSG_ERROR($PHPLPSOLVE55_SHARED_LIBADD)
   PHP_SUBST(PHPLPSOLVE55_SHARED_LIBADD)
 fi
 

--- a/config.m4
+++ b/config.m4
@@ -3,18 +3,7 @@ PHP_ARG_WITH(phplpsolve55, for liblpsolve55,
                           If DIR is not specified, use the system library.])
 
 if test $PHP_PHPLPSOLVE55 != "no"; then
-#  if test -f "$PHP_PHPLPSOLVE55/lp_lib.h"; then
-#    PHP_CHECK_LIBRARY(lpsolve55, make_lp,,[AC_MSG_ERROR([Invalid phplpsolve55 library, make_lp() not found])])
-#  else
-#    dnl This will cancel configuration if the required headers aren't found
-#    AC_MSG_ERROR([lp_lib.h not found])
-#  fi
-
-#  PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, /usr/local/lib, PHPLPSOLVE55_SHARED_LIBADD)
-  #PHP_ADD_LIBRARY(lpsolve55,, PHPLPSOLVE55_SHARED_LIBADD)
-  #PHP_ADD_LIBRARY(lpsolve55)
   EXTRA_LIBS="-lm"
-  #AC_MSG_ERROR($LDFLAGS)
   AC_CHECK_LIB(dl, dlopen, [
     EXTRA_LIBS="$EXTRA_LIBS -ldl"
     PHP_ADD_LIBRARY(dl, 1, PHPLPSOLVE55_SHARED_LIBADD)
@@ -42,7 +31,6 @@ if test $PHP_PHPLPSOLVE55 != "no"; then
   for i in /usr/local/lib /usr/lib /lib; do
     if test -r "$i/liblpsolve55.so"; then
       PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
-          #AC_DEFINE([HAVE_LIBLPSOLVE55], 1, [liblpsolve55 found and included])
           PHP_ADD_LIBRARY_WITH_PATH(lpsolve55, $i, PHPLPSOLVE55_SHARED_LIBADD)
           PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
           LIBLPSOLVE_LIBDIR="$i"
@@ -58,7 +46,6 @@ if test $PHP_PHPLPSOLVE55 != "no"; then
 
   if test -z "$LIBLPSOLVE_LIBDIR"; then
   PHP_CHECK_LIBRARY(lpsolve55, make_lp,[
-        #AC_DEFINE([HAVE_LIBLPSOLVE55], 1, [liblpsolve55 found and included])
         PHP_ADD_LIBRARY(lpsolve55, 1, PHPLPSOLVE55_SHARED_LIBADD)
         PHP_ADD_INCLUDE($LIBLPSOLVE_INCDIR)
         LIBLPSOLVE_LIBDIR="$i"
@@ -73,7 +60,4 @@ if test $PHP_PHPLPSOLVE55 != "no"; then
   AC_DEFINE(DEMO,1,[DEMO code in lpsolve])
   AC_DEFINE(PHP,1,[liblpsolve55 found and included])
   PHP_NEW_EXTENSION(phplpsolve55, PHPmod.c hash.c lpsolve.c, $ext_shared)
-  #AC_MSG_ERROR($PHPLPSOLVE55_SHARED_LIBADD)
-  PHP_SUBST(PHPLPSOLVE55_SHARED_LIBADD)
 fi
-

--- a/hash.c
+++ b/hash.c
@@ -8,7 +8,7 @@
 
 #include <sys/types.h>
 #include <stdlib.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "hash.h"

--- a/hash.c
+++ b/hash.c
@@ -8,7 +8,6 @@
 
 #include <sys/types.h>
 #include <stdlib.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "hash.h"

--- a/hash.h
+++ b/hash.h
@@ -23,13 +23,14 @@ typedef struct _hashtable
 extern "C" {
 #endif
 
-hashtable *create_hash_table(int size, int base);
-void      free_hash_table(hashtable *ht);
-hashelem  *findhash(const char *name, hashtable *ht);
-hashelem  *puthash(const char *name, int index, hashelem **list, hashtable *ht);
-void      drophash(const char *name, hashelem **list, hashtable *ht);
-void      free_hash_item(hashelem **hp);
-hashtable *copy_hash_table(hashtable *ht, hashelem **list, int newsize);
+static inline hashtable *create_hash_table(int size, int base);
+static inline void      free_hash_table(hashtable *ht);
+static inline hashelem  *findhash(const char *name, hashtable *ht);
+static inline hashelem  *puthash(const char *name, int index, hashelem **list, hashtable *ht);
+static inline void      drophash(const char *name, hashelem **list, hashtable *ht);
+static inline void      free_hash_item(hashelem **hp);
+static inline hashtable *copy_hash_table(hashtable *ht, hashelem **list, int newsize);
+static inline int       hashval(const char *string, int size);
 
 #ifdef __cplusplus
  }

--- a/tests/01-empty.phpt
+++ b/tests/01-empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Empty test
+--SKIPIF--
+<?php
+if(!extension_loaded("lpsolve")) echo 'skip';
+?>
+--FILE--
+<?php
+var_dump(lpsolve('make_lp', 0, 0));
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
The `config.m4` file has been modified in order to match current FreeBSD and Linux configurations.
Also, on `hash.c` `malloc.h` include has been changed to `stdlib.h` as it throws errors on FreeBSD.

The `./configure` script will try to automatically discover the correct lpsolve library and its `lp_lib.h`. If the library is not correctly discovered it will throw an error and `--with-phplpsolve55=DIR` parameter should be set on `./configure` in order to work.

A very basic test has been included and it can be executed via `make test`.

Current compilation instructions:
```
phpize
./configure
make
make test
```